### PR TITLE
option to disables strict schema during matchSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ In addition following options are supported
 | dataPoolDataSource | none | none implies the value is not set and the connector should write to SQl Server Single Instance. Set this value to data source name to write a Data Pool Table in Big Data Cluster|
 | isolationLevel | "READ_COMMITTED" | Specify the isolation level |
 | tableLock | "false" | Implements an insert with TABLOCK option to improve write performance |
+| schemaCheckEnabled | "true" | Disables strict dataframe and sql table schema check when set to false |
 
 Other [Bulk api options](https://docs.microsoft.com/en-us/sql/connect/jdbc/using-bulk-copy-with-the-jdbc-driver?view=sql-server-2017#sqlserverbulkcopyoptions) can be set as options on the dataframe and will be passed to bulkcopy apis on write
 

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
@@ -55,6 +55,10 @@ class SQLServerBulkJdbcOptions(val params: CaseInsensitiveMap[String])
   val allowEncryptedValueModifications =
     params.getOrElse("allowEncryptedValueModifications", "false").toBoolean
 
+
+  val schemaCheckEnabled =
+    params.getOrElse("schemaCheckEnabled", "true").toBoolean
+
   // Not a feature
   // Only used for internally testing data idempotency
   val testDataIdempotency =

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
@@ -242,7 +242,7 @@ object BulkCopyUtils extends Logging {
         val tableCols = getSchema(rs, JdbcDialects.get(url))
         val prefix = "Spark Dataframe and SQL Server table have differing"
 
-        assertCondition(dfCols.length == tableCols.length,
+        assertIfCheckEnabled(dfCols.length == tableCols.length, strictSchemaCheck,
             s"${prefix} numbers of columns")
 
         val result = new Array[ColumnMetadata](tableCols.length)


### PR DESCRIPTION
option to disables strict schema during matchSchema by setting schemaCheckEnabled as False

  df.write \
    .format("com.microsoft.sqlserver.jdbc.spark") \
    .mode("overwrite") \
    ..
    .option("truncate", True) \
    .option("schemaCheckEnabled", False) \
    .save()
