### PR TITLE
Skip ColumnMetadata for computed columns

### DIFF
--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
@@ -324,7 +324,8 @@ object BulkCopyUtils extends Logging {
         }
 
 
-        val result = new Array[ColumnMetadata](tableCols.length)
+        val result = new Array[ColumnMetadata](tableCols.length - computedCols.length)
+        var mappingIndex = 0;
 
         for (i <- 0 to tableCols.length-1) {
             val tableColName = tableCols(i).name
@@ -377,15 +378,21 @@ object BulkCopyUtils extends Logging {
                         s" Table col ${tableColName} nullable config is ${tableCols(i).nullable}")
             }
 
-            // Schema check passed for element, Create ColMetaData
-            result(i) = new ColumnMetadata(
-                rs.getMetaData().getColumnName(i+1),
-                rs.getMetaData().getColumnType(i+1),
-                rs.getMetaData().getPrecision(i+1),
-                rs.getMetaData().getScale(i+1),
-                isAutoIncrement,
-                dfFieldIndex
-            )
+            // Schema check passed for element, Create ColMetaData, but only
+            // if the column has a mapping
+            if (dfFieldIndex != -1)
+            {
+                result(mappingIndex) = new ColumnMetadata(
+                    rs.getMetaData().getColumnName(i+1),
+                    rs.getMetaData().getColumnType(i+1),
+                    rs.getMetaData().getPrecision(i+1),
+                    rs.getMetaData().getScale(i+1),
+                    isAutoIncrement,
+                    dfFieldIndex
+                )
+
+                mappingIndex += 1
+            }
         }
         result
     }


### PR DESCRIPTION
If a table has a computed column anywhere but the
'end' of the table, then the earlier fix for computed
columns does not work. This commit addresses that issue
by ensuring that new ColumnMetadata is only created and
added to the array for non-computed columns.