### PR TITLE
remove serialversionId warning

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/spark/DataFrameBulkRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/spark/DataFrameBulkRecord.java
@@ -35,6 +35,8 @@ public class DataFrameBulkRecord implements ISQLServerBulkRecord, AutoCloseable 
     private ColumnMetadata[] dfColumnMetadata;
     private Set<Integer> columnOrdinals;
 
+    private static final long serialVersionUID = 1L;
+    
     public DataFrameBulkRecord(Iterator<Row> iterator, ColumnMetadata[] dfColumnMetadata) {
         this.iterator = iterator;
         this.dfColumnMetadata = dfColumnMetadata;


### PR DESCRIPTION
removing warning

```
[warn] sql-spark-connector/src/main/java/com/microsoft/sqlserver/jdbc/spark/DataFrameBulkRecord.java:33:1: serializable class com.microsoft.sqlserver.jdbc.spark.DataFrameBulkRecord has no definition of serialVersionUID
```