### PR TITLE
skip computed col in colMetaData

### DIFF
--- a/samples/computed-col-test-cases/computed-col-test.ipynb
+++ b/samples/computed-col-test-cases/computed-col-test.ipynb
@@ -1,0 +1,461 @@
+{
+    "metadata": {
+        "kernelspec": {
+            "name": "pysparkkernel",
+            "display_name": "PySpark",
+            "language": ""
+        },
+        "language_info": {
+            "name": "pyspark",
+            "mimetype": "text/x-python",
+            "codemirror_mode": {
+                "name": "python",
+                "version": 3
+            },
+            "pygments_lexer": "python3"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {
+            "cell_type": "code",
+            "source": [
+                "# spark = SparkSession.builder.getOrCreate()\r\n",
+                "# sc.setLogLevel(\"INFO\")\r\n",
+                "spark.sparkContext.setLogLevel('DEBUG')\r\n",
+                "data = [(1, \"2020\", \"01\"),\r\n",
+                "        (2, \"2020\", \"02\"),\r\n",
+                "        (3, \"2020\", \"03\")]\r\n",
+                "columns = [\"Id\", \"Year\", \"Month\"]\r\n",
+                "df = spark.createDataFrame(data = data, schema = columns)\r\n",
+                "df.show()"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "fd51c6bb-ca56-47f7-b8ed-62baad1bd782",
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "text": "Starting Spark application\n",
+                    "output_type": "stream"
+                },
+                {
+                    "data": {
+                        "text/plain": "<IPython.core.display.HTML object>",
+                        "text/html": "<table>\n<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr><tr><td>3</td><td>application_1617815319900_0008</td><td>pyspark</td><td>idle</td><td><a target=\"_blank\" href=\"https://10.193.18.148:30443/gateway/default/yarn/proxy/application_1617815319900_0008/\">Link</a></td><td><a target=\"_blank\" href=\"https://10.193.18.148:30443/gateway/default/yarn/container/container_1617815319900_0008_01_000001/livy\">Link</a></td><td>✔</td></tr></table>"
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "38d9bc1016e047b9b974ccaab4f34ad8"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "SparkSession available as 'spark'.\n",
+                    "output_type": "stream"
+                },
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "fec6769d00164cb5a00c6f72cf40cf5b"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "+---+----+-----+\n| Id|Year|Month|\n+---+----+-----+\n|  1|2020|   01|\n|  2|2020|   02|\n|  3|2020|   03|\n+---+----+-----+",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 2
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "servername = \"jdbc:sqlserver://master-0.master-svc\"\r\n",
+                "dbname = \"connector_test_db1\"\r\n",
+                "url = servername + \";\" + \"databaseName=\" + dbname + \";\"\r\n",
+                "\r\n",
+                "user = \"connector_user1\"\r\n",
+                "password = \"password123!#\" # Please specify password here"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "fdc8b9c8-36eb-4280-b32e-6a95b0e11e45"
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "802063b9be4e4abf97c8fc2b84789b32"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                }
+            ],
+            "execution_count": 3
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "## append with computed columns at start and end\r\n",
+                "# Write from Spark to SQL table using MSSQL Spark Connector\r\n",
+                "dbtable = \"test1\"\r\n",
+                "\r\n",
+                "try:\r\n",
+                "  df.write \\\r\n",
+                "    .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "    .mode(\"append\") \\\r\n",
+                "    .option(\"url\", url) \\\r\n",
+                "    .option(\"dbtable\", dbtable) \\\r\n",
+                "    .option(\"user\", user) \\\r\n",
+                "    .option(\"password\", password) \\\r\n",
+                "    .save()\r\n",
+                "except ValueError as error :\r\n",
+                "    print(\"MSSQL Connector write failed\", error)\r\n",
+                "\r\n",
+                "print(\"MSSQL Connector write(append) succeeded  \")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "2f936a04-6110-47d7-ab25-87308576ab57"
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "4ebad3e502dd48a2924e8762da7de964"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "MSSQL Connector write(append) succeeded",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 25
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "#Read from SQL table using MSSQ Connector\r\n",
+                "dbtable = \"test1\"\r\n",
+                "\r\n",
+                "jdbcDF = spark.read \\\r\n",
+                "        .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "        .option(\"url\", url) \\\r\n",
+                "        .option(\"dbtable\", dbtable) \\\r\n",
+                "        .option(\"user\", user) \\\r\n",
+                "        .option(\"password\", password).load()\r\n",
+                "\r\n",
+                "jdbcDF.show(5)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "f957925e-2d9a-4cf0-a610-28fcf1e746ba"
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "2fd8cdda3c284875944c0399527cd36a"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "+-------+---+----+-----+--------+\n|   Date| Id|Year|Month|   Years|\n+-------+---+----+-----+--------+\n|2020-01|  1|2020|   01|20202020|\n|2020-02|  2|2020|   02|20202020|\n|2020-03|  3|2020|   03|20202020|\n+-------+---+----+-----+--------+",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 26
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "## append with 1 computed column in between\r\n",
+                "# Write from Spark to SQL table using MSSQL Spark Connector\r\n",
+                "dbtable = \"test2\"\r\n",
+                "\r\n",
+                "try:\r\n",
+                "  df.write \\\r\n",
+                "    .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "    .mode(\"append\") \\\r\n",
+                "    .option(\"url\", url) \\\r\n",
+                "    .option(\"dbtable\", dbtable) \\\r\n",
+                "    .option(\"user\", user) \\\r\n",
+                "    .option(\"password\", password) \\\r\n",
+                "    .save()\r\n",
+                "except ValueError as error :\r\n",
+                "    print(\"MSSQL Connector write failed\", error)\r\n",
+                "\r\n",
+                "print(\"MSSQL Connector write(append) succeeded  \")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "f51da718-8527-45c0-a739-b0e64af4e7a6",
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "aa66d89ae91e464989173d8c25012168"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "MSSQL Connector write(append) succeeded",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 23
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "#Read from SQL table using MSSQL Connector\r\n",
+                "dbtable = \"test2\"\r\n",
+                "\r\n",
+                "jdbcDF = spark.read \\\r\n",
+                "        .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "        .option(\"url\", url) \\\r\n",
+                "        .option(\"dbtable\", dbtable) \\\r\n",
+                "        .option(\"user\", user) \\\r\n",
+                "        .option(\"password\", password).load()\r\n",
+                "\r\n",
+                "jdbcDF.show(5)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "bd1b3ccd-3ed7-4b21-9b57-95d1d774d76e"
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "3ce2396102ee419192cd8f41c06ea044"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "+---+-------+----+-----+\n| Id|   Date|Year|Month|\n+---+-------+----+-----+\n|  1|2020-01|2020|   01|\n|  2|2020-02|2020|   02|\n|  3|2020-03|2020|   03|\n+---+-------+----+-----+",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 24
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "## append with 2 computed columns in between\r\n",
+                "# Write from Spark to SQL table using MSSQL Spark Connector\r\n",
+                "dbtable = \"test3\"\r\n",
+                "\r\n",
+                "try:\r\n",
+                "  df.write \\\r\n",
+                "    .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "    .mode(\"append\") \\\r\n",
+                "    .option(\"url\", url) \\\r\n",
+                "    .option(\"dbtable\", dbtable) \\\r\n",
+                "    .option(\"user\", user) \\\r\n",
+                "    .option(\"password\", password) \\\r\n",
+                "    .option(\"schemaCheckEnabled\", False) \\\r\n",
+                "    .save()\r\n",
+                "except ValueError as error :\r\n",
+                "    print(\"MSSQL Connector write failed\", error)\r\n",
+                "\r\n",
+                "print(\"MSSQL Connector write(append) done  \")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "10bbf920-e50f-4098-be1b-f06024a52fac",
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "2967ac7f14e34d27970e0833b7eb5645"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "MSSQL Connector write(append) done",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 21
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "#Read from SQL table using MSSQL Connector\r\n",
+                "dbtable = \"test3\"\r\n",
+                "\r\n",
+                "jdbcDF = spark.read \\\r\n",
+                "        .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "        .option(\"url\", url) \\\r\n",
+                "        .option(\"dbtable\", dbtable) \\\r\n",
+                "        .option(\"user\", user) \\\r\n",
+                "        .option(\"password\", password).load()\r\n",
+                "\r\n",
+                "jdbcDF.show(5)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "1c81ee7d-62bc-4a4d-acfa-900b6efeb6ec",
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "c610b609efaa4d27b53e1a48a417888e"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "+---+-------+----+--------+-----+\n| Id|   Date|Year|   Years|Month|\n+---+-------+----+--------+-----+\n|  1|2020-01|2020|20202020|   01|\n|  2|2020-02|2020|20202020|   02|\n|  3|2020-03|2020|20202020|   03|\n+---+-------+----+--------+-----+",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 22
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "## append with 1 computed column in df and table, but table has 1 less col\r\n",
+                "# set schemaCheckEnabled\" as False\r\n",
+                "# Write from Spark to SQL table using MSSQL Spark Connector\r\n",
+                "dbtable = \"test4\"\r\n",
+                "\r\n",
+                "try:\r\n",
+                "  df.write \\\r\n",
+                "    .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "    .mode(\"append\") \\\r\n",
+                "    .option(\"url\", url) \\\r\n",
+                "    .option(\"dbtable\", dbtable) \\\r\n",
+                "    .option(\"user\", user) \\\r\n",
+                "    .option(\"password\", password) \\\r\n",
+                "    .option(\"schemaCheckEnabled\", False) \\\r\n",
+                "    .save()\r\n",
+                "except ValueError as error :\r\n",
+                "    print(\"MSSQL Connector write failed\", error)\r\n",
+                "\r\n",
+                "print(\"MSSQL Connector write(append) done  \")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "0fcd38ab-a367-45e7-8d80-acb978176c82"
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "98bb7592e1b24920909dd4ed6542737a"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "MSSQL Connector write(append) done",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 19
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "#Read from SQL table using MSSQL Connector\r\n",
+                "dbtable = \"test4\"\r\n",
+                "\r\n",
+                "jdbcDF = spark.read \\\r\n",
+                "        .format(\"com.microsoft.sqlserver.jdbc.spark\") \\\r\n",
+                "        .option(\"url\", url) \\\r\n",
+                "        .option(\"dbtable\", dbtable) \\\r\n",
+                "        .option(\"user\", user) \\\r\n",
+                "        .option(\"password\", password).load()\r\n",
+                "\r\n",
+                "jdbcDF.show(5)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "bb9add17-d962-4e9d-b407-cf1d43cbaf98"
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": "f7300341de024a018ddad006b91624fc"
+                        }
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                },
+                {
+                    "name": "stdout",
+                    "text": "+---+----+--------+\n| Id|Year|   Years|\n+---+----+--------+\n|  1|2020|20202020|\n|  2|2020|20202020|\n|  3|2020|20202020|\n+---+----+--------+",
+                    "output_type": "stream"
+                }
+            ],
+            "execution_count": 20
+        }
+    ]
+}

--- a/samples/computed-col-test-cases/sql-table-generation.ipynb
+++ b/samples/computed-col-test-cases/sql-table-generation.ipynb
@@ -1,0 +1,229 @@
+{
+    "metadata": {
+        "kernelspec": {
+            "name": "SQL",
+            "display_name": "SQL",
+            "language": "sql"
+        },
+        "language_info": {
+            "name": "sql",
+            "version": ""
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {
+            "cell_type": "code",
+            "source": [
+                "CREATE DATABASE connector_test_db1"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "5b1fd0a6-20b8-4e6a-9578-10bea2a3a43d"
+            },
+            "outputs": [
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Commands completed successfully."
+                    },
+                    "metadata": {}
+                },
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Total execution time: 00:00:00.640"
+                    },
+                    "metadata": {}
+                }
+            ],
+            "execution_count": 1
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "Use connector_test_db1;\r\n",
+                "CREATE LOGIN connector_user1  WITH PASSWORD ='password123!#' \r\n",
+                "CREATE USER connector_user1 FROM LOGIN connector_user1\r\n",
+                "\r\n",
+                "-- to view data pool node configuration\r\n",
+                "grant VIEW DATABASE STATE to connector_user1\r\n",
+                "\r\n",
+                "-- To create external tables in data pools\r\n",
+                "grant alter any external data source to connector_user1;\r\n",
+                "\r\n",
+                "-- To create external table\r\n",
+                "grant create table to connector_user1;\r\n",
+                "grant alter any schema to connector_user1;\r\n",
+                "\r\n",
+                "\r\n",
+                "\r\n",
+                "ALTER ROLE [db_datareader] ADD MEMBER connector_user1\r\n",
+                "ALTER ROLE [db_datawriter] ADD MEMBER connector_user1"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "378bb099-8499-4661-9745-527a1ed19579"
+            },
+            "outputs": [
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Commands completed successfully."
+                    },
+                    "metadata": {}
+                },
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Total execution time: 00:00:00.108"
+                    },
+                    "metadata": {}
+                }
+            ],
+            "execution_count": 2
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "-- append with computed columns at start and end\r\n",
+                "USE connector_test_db1;\r\n",
+                "\r\n",
+                "CREATE TABLE test1\r\n",
+                "(\r\n",
+                "    Date As (Year + '-' + Month),\r\n",
+                "    Id bigint,\r\n",
+                "    Year nvarchar(4),\r\n",
+                "    Month nvarchar(2),\r\n",
+                "    Years AS REPLICATE(Year, 2)\r\n",
+                ")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "dde73601-c253-45c8-b385-94da828ef6da"
+            },
+            "outputs": [
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Commands completed successfully."
+                    },
+                    "metadata": {}
+                },
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Total execution time: 00:00:00.090"
+                    },
+                    "metadata": {}
+                }
+            ],
+            "execution_count": 10
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "-- append with 1 computed column in between\r\n",
+                "USE connector_test_db1;\r\n",
+                "CREATE TABLE test2\r\n",
+                "(\r\n",
+                "    Id bigint,\r\n",
+                "    Date As (Year + '-' + Month),\r\n",
+                "    Year nvarchar(4),\r\n",
+                "    Month nvarchar(2)\r\n",
+                ")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "d25fe7a7-c8cf-498e-89f9-3335277a2db1",
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Commands completed successfully."
+                    },
+                    "metadata": {}
+                },
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Total execution time: 00:00:00.103"
+                    },
+                    "metadata": {}
+                }
+            ],
+            "execution_count": 11
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "-- append with 2 computed columns in between\r\n",
+                "USE connector_test_db1;\r\n",
+                "\r\n",
+                "CREATE TABLE test3\r\n",
+                "(\r\n",
+                "    Id bigint,\r\n",
+                "    Date As (Year + '-' + Month),\r\n",
+                "    Year nvarchar(4),\r\n",
+                "    Years AS REPLICATE(Year, 2),\r\n",
+                "    Month nvarchar(2)\r\n",
+                ")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "2b952d30-7ca9-49d4-9cd8-92a35d30d881",
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Commands completed successfully."
+                    },
+                    "metadata": {}
+                },
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Total execution time: 00:00:00.089"
+                    },
+                    "metadata": {}
+                }
+            ],
+            "execution_count": 12
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "-- append with 1 computed column in df and table, but table has 1 less col\r\n",
+                "USE connector_test_db1;\r\n",
+                "\r\n",
+                "CREATE TABLE test4\r\n",
+                "(\r\n",
+                "    Id bigint,\r\n",
+                "    Year nvarchar(4),\r\n",
+                "    Years AS REPLICATE(Year, 2)\r\n",
+                ")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "e7b24025-05e0-40de-992f-0ca41bfcc246",
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Commands completed successfully."
+                    },
+                    "metadata": {}
+                },
+                {
+                    "output_type": "display_data",
+                    "data": {
+                        "text/html": "Total execution time: 00:00:00.257"
+                    },
+                    "metadata": {}
+                }
+            ],
+            "execution_count": 16
+        }
+    ]
+}

--- a/src/main/java/com/microsoft/sqlserver/jdbc/spark/ColumnMetadata.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/spark/ColumnMetadata.java
@@ -22,15 +22,13 @@ public class ColumnMetadata implements Serializable {
     private int type;
     private int precision;
     private int scale;
-    private boolean isAutoIncrement;
     private int dfColIndex; // index of this column in the dataframe.
 
-    public ColumnMetadata(String name, int type, int precision, int scale, boolean isAutoIncrement, int dfColIndex) {
+    public ColumnMetadata(String name, int type, int precision, int scale, int dfColIndex) {
         this.name = name;
         this.type = type;
         this.precision = precision;
         this.scale = scale;
-        this.isAutoIncrement = isAutoIncrement;
         this.dfColIndex = dfColIndex;
     }
 
@@ -48,10 +46,6 @@ public class ColumnMetadata implements Serializable {
 
     public int getScale() {
         return scale;
-    }
-
-    public boolean isAutoIncrement() {
-        return isAutoIncrement;
     }
 
     public int getDfColIndex() {

--- a/src/main/java/com/microsoft/sqlserver/jdbc/spark/DataFrameBulkRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/spark/DataFrameBulkRecord.java
@@ -46,9 +46,7 @@ public class DataFrameBulkRecord implements ISQLServerBulkData, AutoCloseable {
              // Columns may be reordered between SQLTable and DataFrame. dfFieldIndex maps to the
              // corresponding column in rowData and thus use dfFieldIndex to get the column.
              int dfFieldIndex = dfColumnMetadata[idx].getDfColIndex();
-             if (!dfColumnMetadata[idx].isAutoIncrement()) {
-                 rowData[idx] = row.get(dfFieldIndex);
-             }
+             rowData[idx] = row.get(dfFieldIndex);
         }
         return rowData;
     }

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
@@ -233,7 +233,6 @@ object BulkCopyUtils extends Logging {
                 metadata.getColumnType(idx+1),
                 metadata.getPrecision(idx+1),
                 metadata.getScale(idx+1),
-                metadata.isAutoIncrement(idx+1),
                 idx)
         }
         result
@@ -323,15 +322,13 @@ object BulkCopyUtils extends Logging {
 
 
         val result = new Array[ColumnMetadata](tableCols.length - computedCols.length)
-        var mappingIndex = 0
+        var nonAutoColIndex = 0
 
         for (i <- 0 to tableCols.length-1) {
             val tableColName = tableCols(i).name
             var dfFieldIndex = -1
-            var isAutoIncrement = false
+            // set dfFieldIndex = -1 for all computed columns to skip ColumnMetadata
             if (computedCols.contains(tableColName)) {
-                // set dfFieldIndex = -1 and isAutoIncrement = true for all computed columns to skip bulk copy mapping
-                isAutoIncrement = true
                 logDebug(s"skipping computed col index $i col name $tableColName dfFieldIndex $dfFieldIndex")
             }else{
                 var dfColName:String = ""
@@ -374,20 +371,17 @@ object BulkCopyUtils extends Logging {
                     s"${prefix} column nullable configurations at column index ${i}" +
                         s" DF col ${dfColName} nullable config is ${dfCols(dfFieldIndex).nullable} " +
                         s" Table col ${tableColName} nullable config is ${tableCols(i).nullable}")
-            }
 
-            // Schema check passed for element, Create ColMetaData
-            if(dfFieldIndex != -1){
-                result(mappingIndex) = new ColumnMetadata(
+                // Schema check passed for element, Create ColMetaData only for non auto generated column
+                result(nonAutoColIndex) = new ColumnMetadata(
                     rs.getMetaData().getColumnName(i+1),
                     rs.getMetaData().getColumnType(i+1),
                     rs.getMetaData().getPrecision(i+1),
                     rs.getMetaData().getScale(i+1),
-                    isAutoIncrement,
                     dfFieldIndex
                 )
-                mappingIndex += 1
-            }  
+                nonAutoColIndex += 1
+            }
         }
         result
     }

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
@@ -103,9 +103,7 @@ object BulkCopyUtils extends Logging {
         sqlServerBulkCopy.setDestinationTableName(tableName)
 
         for (i <- 0 to dfColMetadata.length-1) {
-            if (!dfColMetadata(i).isAutoIncrement()){
-                sqlServerBulkCopy.addColumnMapping(dfColMetadata(i).getName(), dfColMetadata(i).getName())
-            }
+            sqlServerBulkCopy.addColumnMapping(dfColMetadata(i).getName(), dfColMetadata(i).getName())
         }
 
         val bulkRecord = new DataFrameBulkRecord(iterator, dfColMetadata)
@@ -324,7 +322,8 @@ object BulkCopyUtils extends Logging {
         }
 
 
-        val result = new Array[ColumnMetadata](tableCols.length)
+        val result = new Array[ColumnMetadata](tableCols.length - computedCols.length)
+        var mappingIndex = 0
 
         for (i <- 0 to tableCols.length-1) {
             val tableColName = tableCols(i).name
@@ -378,14 +377,17 @@ object BulkCopyUtils extends Logging {
             }
 
             // Schema check passed for element, Create ColMetaData
-            result(i) = new ColumnMetadata(
-                rs.getMetaData().getColumnName(i+1),
-                rs.getMetaData().getColumnType(i+1),
-                rs.getMetaData().getPrecision(i+1),
-                rs.getMetaData().getScale(i+1),
-                isAutoIncrement,
-                dfFieldIndex
-            )
+            if(dfFieldIndex != -1){
+                result(mappingIndex) = new ColumnMetadata(
+                    rs.getMetaData().getColumnName(i+1),
+                    rs.getMetaData().getColumnType(i+1),
+                    rs.getMetaData().getPrecision(i+1),
+                    rs.getMetaData().getScale(i+1),
+                    isAutoIncrement,
+                    dfFieldIndex
+                )
+                mappingIndex += 1
+            }  
         }
         result
     }

--- a/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
@@ -34,15 +34,13 @@ public class DataSourceUtilsTest {
         int type = Types.INTEGER;
         int precision = 50;
         int scale = 10;
-        Boolean isAutoIncrement = true;
 
-        ColumnMetadata columnMetadata = new ColumnMetadata(name, type, precision, scale, isAutoIncrement,20);
+        ColumnMetadata columnMetadata = new ColumnMetadata(name, type, precision, scale,20);
 
         assertEquals(name, columnMetadata.getName());
         assertEquals(type, columnMetadata.getType());
         assertEquals(precision, columnMetadata.getPrecision());
         assertEquals(scale, columnMetadata.getScale());
-        assertEquals(isAutoIncrement, columnMetadata.isAutoIncrement());
     }
 
     @Test
@@ -53,8 +51,8 @@ public class DataSourceUtilsTest {
         };
 
         ColumnMetadata[] metadata = new ColumnMetadata[] {
-            new ColumnMetadata("entry_number", Types.INTEGER, 10, 5, true,20),
-            new ColumnMetadata("entry_word", Types.LONGVARCHAR, 20, 4, false,20)
+            new ColumnMetadata("entry_number", Types.INTEGER, 10, 5,20),
+            new ColumnMetadata("entry_word", Types.LONGVARCHAR, 20, 4,20)
         };
 
         Iterator<Row> itr = JavaConversions.asScalaIterator(Arrays.asList(rows).iterator());


### PR DESCRIPTION
If a table has a computed column anywhere but the 'end' of the table, then the earlier fix for computed columns does not work. This commit addresses that issue by ensuring that new ColumnMetadata is only created and added to the array for non-computed columns. 
This PR provided the same fix as PR #81  
This PR is been tested with CI/GCI test cases and test cases with computed column.

## Repro:
### sql table setup
```
CREATE TABLE test
(
    Id bigint,
    Date As (Year + '-' + Month),
    Year nvarchar(4),
    Month nvarchar(2)
)
```

### Pyspark code
```
#data generate
data = [(1, "2020", "01"),
        (2, "2020", "02"),
        (3, "2020", "03")]
columns = ["Id", "Year", "Month"]
df = spark.createDataFrame(data = data, schema = columns)

#append to sql table 
servername = "jdbc:sqlserver://master-0.master-svc"
dbname = "connector_test_db"
url = servername + ";" + "databaseName=" + dbname + ";"

dbtable = "test"
user = "connector_user1"
password = "password123!#"

try:
  df.write \
    .format("com.microsoft.sqlserver.jdbc.spark") \
    .mode("append") \
    .option("url", url) \
    .option("dbtable", dbtable) \
    .option("user", user) \
    .option("password", password) \
    .save()
except ValueError as error :
    print("MSSQL Connector write failed", error)

print("MSSQL Connector write(overwrite) succeeded  ")
```
### Result:
```
An error was encountered:
Caused by: java.lang.ArrayIndexOutOfBoundsException: 3
	at com.microsoft.sqlserver.jdbc.spark.DataFrameBulkRecord.getRowData(DataFrameBulkRecord.java:50)
	at com.microsoft.sqlserver.jdbc.SQLServerBulkCopy.writeBatchData(SQLServerBulkCopy.java:3623)
```

The expected result is a table, with second column auto filled (Year-Month). We can get it after this fix:
```
Id|   Date|Year|Month|
+---+-------+----+-----+
|  1|2020-01|2020|   01|
|  2|2020-02|2020|   02|
|  3|2020-03|2020|   03|
```