### PR TITLE
Add support for the sql server graph tables. Support spark version 3.

### DIFF
--- a/.github/workflows/scala2.yml
+++ b/.github/workflows/scala2.yml
@@ -1,0 +1,21 @@
+name: Scala CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Run tests
+      run: sbt test

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,10 @@
     </organization>
     <licenses>
         <license>
-            <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.binary.version>2.11</scala.binary.version>
-        <scala.version>2.11.12</scala.version>
-        <spark.version>2.4.6</spark.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -57,12 +51,6 @@
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.0.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.novocode</groupId>
             <artifactId>junit-interface</artifactId>
             <version>0.11</version>
@@ -71,7 +59,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>7.2.1.jre8</version>
+            <version>8.4.1.jre8</version>
         </dependency>
     </dependencies>
     <developers>
@@ -213,4 +201,48 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+    <profile>
+        <id>spark24</id>
+        <properties>
+            <scala.binary.version>2.11</scala.binary.version>
+            <scala.version>2.11.12</scala.version>
+            <spark.version>2.4.6</spark.version>
+        </properties>
+        <dependencies>
+            <dependency>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest_${scala.binary.version}</artifactId>
+                <version>3.0.5</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>7.2.1.jre8</version>
+            </dependency>
+        </dependencies>
+    </profile>
+    <profile>
+        <id>spark30</id>
+        <properties>
+            <scala.binary.version>2.12</scala.binary.version>
+            <scala.version>2.12.11</scala.version>
+            <spark.version>3.0.0</spark.version>
+        </properties>
+        <dependencies>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>3.0.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>8.2.2.jre8</version>
+        </dependency>
+        </dependencies>
+    </profile>
+    </profiles>
 </project>

--- a/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
@@ -34,15 +34,13 @@ public class DataSourceUtilsTest {
         int type = Types.INTEGER;
         int precision = 50;
         int scale = 10;
-        Boolean isAutoIncrement = true;
 
-        ColumnMetadata columnMetadata = new ColumnMetadata(name, type, precision, scale, isAutoIncrement,20);
+        ColumnMetadata columnMetadata = new ColumnMetadata(name, type, precision, scale,20);
 
         assertEquals(name, columnMetadata.getName());
         assertEquals(type, columnMetadata.getType());
         assertEquals(precision, columnMetadata.getPrecision());
         assertEquals(scale, columnMetadata.getScale());
-        assertEquals(isAutoIncrement, columnMetadata.isAutoIncrement());
     }
 
     @Test
@@ -53,8 +51,8 @@ public class DataSourceUtilsTest {
         };
 
         ColumnMetadata[] metadata = new ColumnMetadata[] {
-            new ColumnMetadata("entry_number", Types.INTEGER, 10, 5, true,20),
-            new ColumnMetadata("entry_word", Types.LONGVARCHAR, 20, 4, false,20)
+            new ColumnMetadata("entry_number", Types.INTEGER, 10, 5,20),
+            new ColumnMetadata("entry_word", Types.LONGVARCHAR, 20, 4,20)
         };
 
         Iterator<Row> itr = JavaConversions.asScalaIterator(Arrays.asList(rows).iterator());
@@ -66,32 +64,10 @@ public class DataSourceUtilsTest {
         assertTrue(columnOrdinals.size() == 2);
 
         for (int i = 0; i < metadata.length; i++) {
-            assertEquals(record.getColumnName(i+1),   metadata[i].getName());
-            assertEquals(record.getColumnType(i+1),   metadata[i].getType());
-            assertEquals(record.getPrecision(i+1),    metadata[i].getPrecision());
-            assertEquals(record.getScale(i+1),        metadata[i].getScale());
-            assertEquals(record.isAutoIncrement(i+1), metadata[i].isAutoIncrement());
+            assertEquals(record.getColumnName(i+1), metadata[i].getName());
+            assertEquals(record.getColumnType(i+1), metadata[i].getType());
+            assertEquals(record.getPrecision(i+1), metadata[i].getPrecision());
+            assertEquals(record.getScale(i+1), metadata[i].getScale());
         }
-
-//        for (int i = 0; i < rows.length; i++) {
-//            try {
-//                // Assuming that each row has at least two elements
-//                //Object[] rowData = record.getRowData();
-//                assertEquals(rowData[0], rows[i].get(0));
-//                assertEquals(rowData[1], rows[i].get(1));
-//            } catch (SQLServerException e) {
-//                e.printStackTrace();
-//            }
-//        }
-
-//        boolean errorCaught = false;
-//        try {
-//            Object[] rowData = record.getRowData();
-//        } catch (SQLServerException e) {
-//            e.printStackTrace();
-//        } catch (NoSuchElementException e) {
-//            errorCaught = true;
-//        }
-//        assertTrue(errorCaught);
     }
 }

--- a/src/test/scala/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceTest.scala
+++ b/src/test/scala/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceTest.scala
@@ -16,9 +16,9 @@ import java.sql.Connection
 
 import org.scalatest.Matchers
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 
-class DataSourceTest extends SparkFunSuite with Matchers with SharedSQLContext {
+class DataSourceTest extends SparkFunSuite with Matchers with SharedSparkSession {
 
   test("Schema validation between Spark DataFrame and SQL Server ResultSet") {}
 


### PR DESCRIPTION
Add support of writing data to the graph tables. It's done by treating graph columns as computed columns.