### PR TITLE
Support for spark24 and spark30 test app

### DIFF
--- a/test/scala_test/pom.xml
+++ b/test/scala_test/pom.xml
@@ -17,12 +17,6 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.binary.version>2.11</scala.binary.version>
-        <scala.version>2.11.12</scala.version>
-        <spark.version>2.4.6</spark.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -88,7 +82,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
@@ -128,4 +121,22 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>spark24</id>
+            <properties>
+                <scala.binary.version>2.11</scala.binary.version>
+                <scala.version>2.11.12</scala.version>
+                <spark.version>2.4.6</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark30</id>
+            <properties>
+                <scala.binary.version>2.12</scala.binary.version>
+                <scala.version>2.12.11</scala.version>
+                <spark.version>3.0.0</spark.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
# Why?
Change for test app to build for both Spark24 and Spark30

# What changed
- spark 24 and spark30 profiles added in pom.xml 
- Post fix test app can be build as  
     - 'mvn clean package -P spark24'  for spark 2.4
     - 'mvn clean package -P spark30' for spark 3.0

# Test
- Jars for both 24 and 30 build fine.
-  Tested on BDC (spark 2.4) with following 

spark-submit --master yarn --deploy-mode cluster --class SparkConnTestMain /tmp/spark-mssql-connector-scala-test-1.0.0.jar 'connector_user' 'pass' '' '' 'com.microsoft.sqlserver.jdbc.spark' 'connector_test_db' 'spark_mssql_data_source' '0' 'false' 'master-p-svc' '1433' ''