### PR TITLE
[WIP]add braces for table name in sql statement

### DIFF
--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
@@ -191,14 +191,14 @@ object ReliableSingleInstanceStrategy extends  DataIOStrategy with Logging {
                dfColMetadata: Array[ColumnMetadata],
                options: SQLServerBulkJdbcOptions): String = {
     logDebug(s"stmtInsertWithUnion: Staging tables to union are ${stagingTableList.mkString(",")}")
-    val unionStr = stagingTableList.map(item => s"SELECT * from $item").mkString(" UNION ALL ")
+    val unionStr = stagingTableList.map(item => s"SELECT * from [$item]").mkString(" UNION ALL ")
     val colStr = dfColMetadata.map(item => item.getName).mkString(",")
     options.tableLock match {
       case true => {
-       s"INSERT INTO ${options.dbtable} WITH (TABLOCK) $unionStr"
+       s"INSERT INTO [${options.dbtable}] WITH (TABLOCK) $unionStr"
       }
       case false => {
-        s"INSERT INTO ${options.dbtable} $unionStr"
+        s"INSERT INTO [${options.dbtable}] $unionStr"
       }
     }
   }
@@ -232,7 +232,7 @@ object ReliableSingleInstanceStrategy extends  DataIOStrategy with Logging {
                tableName : String,
                options: SQLServerBulkJdbcOptions) : Unit = {
     logDebug(s"createStagingTable : Creating table $tableName as schema copy of ${options.dbtable}")
-    val createTableStr = s"SELECT * INTO $tableName From ${options.dbtable} WHERE 1=0"
+    val createTableStr = s"SELECT * INTO [$tableName] From [${options.dbtable}] WHERE 1=0"
     executeUpdate(conn,createTableStr)
   }
 

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
@@ -483,7 +483,7 @@ object BulkCopyUtils extends Logging {
         conn: Connection, 
         dbtable: String): Unit = {
         logDebug(s"Truncating table ${dbtable}")
-        val truncateTableStr = s"TRUNCATE TABLE ${dbtable}"
+        val truncateTableStr = s"TRUNCATE TABLE [${dbtable}]"
         executeUpdate(conn,truncateTableStr)
         logDebug("Truncating table succeeded")
     }
@@ -500,7 +500,7 @@ object BulkCopyUtils extends Logging {
                         options: SQLServerBulkJdbcOptions): Unit = {
         logDebug("Creating table")
         val strSchema = schemaString(df, options.url, options.createTableColumnTypes)
-        val createTableStr = s"CREATE TABLE ${options.dbtable} (${strSchema}) ${options.createTableOptions}"
+        val createTableStr = s"CREATE TABLE [${options.dbtable}] (${strSchema}) ${options.createTableOptions}"
         executeUpdate(conn,createTableStr)
         logDebug("Creating table succeeded")
     }
@@ -518,7 +518,7 @@ object BulkCopyUtils extends Logging {
         options: SQLServerBulkJdbcOptions): Unit = {
         logDebug(s"Creating external table ${options.dbtable}")
         val strSchema = schemaString(df, "jdbc:sqlserver")
-        val createExTableStr =  s"CREATE EXTERNAL TABLE ${options.dbtable} (${strSchema}) " +
+        val createExTableStr =  s"CREATE EXTERNAL TABLE [${options.dbtable}] (${strSchema}) " +
           s"WITH (DATA_SOURCE=${options.dataPoolDataSource}, DISTRIBUTION=${options.dataPoolDistPolicy});"
         executeUpdate(conn,createExTableStr)
         logDebug("Creating external table succeeded")


### PR DESCRIPTION
When table name has '-', we will see syntax error "Incorrect syntax near '-'". One example is issue #22 . For NO_DUPLICATES mode, if the spark application ID has '-', the staging table names which include app ID will cause error when create table, truncate table etc. 
This fix adds braces for the table names in SQL statement.