### PR TITLE
Add braces to staging table name to make is safe for reserved characters

### DIFF
--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
@@ -178,7 +178,7 @@ object ReliableSingleInstanceStrategy extends  DataIOStrategy with Logging {
                appId: String,
                index:Int) : String = {
     // Global table names in SQLServer are prefixed with ##
-    s"##" + s"$appId" + s"_$index"
+    s"[##${appId}_${index}]"
   }
 
   /**


### PR DESCRIPTION
The NO_DUPLICATES strategy has been problematic for some as this strategy uses the appId to create staging tables.
The appId commonly contains dashes ( - ) and this then results in a failure: `Incorrect syntax near '-'.`

Adding braces around the name of the table will help mitigate this issue.
Relates to https://github.com/microsoft/sql-spark-connector/issues/22

@whaitukay
I rebased the PR #62.