### PR TITLE
activate spark30 profile by default in mvn build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,10 @@
     </profile>
     <profile>
         <id>spark30</id>
-        <properties>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+	<properties>
             <scala.binary.version>2.12</scala.binary.version>
             <scala.version>2.12.11</scala.version>
             <spark.version>3.0.0</spark.version>


### PR DESCRIPTION
There are two pom profiles, spark24 and spark30. This PR is to activate spark30 by default in mvn build.
This PR is tested by building the jar locally.