### PR TITLE
[DRAFT] Set the (default) JDBC application name to "Spark MSSQL Connector"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,8 @@ project/project/
 project/target/
 target/
 .idea
+
+# VS Code generated folders
+.settings
+.classpath
+.project

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/DefaultSource.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/DefaultSource.scala
@@ -52,7 +52,7 @@ class DefaultSource extends JdbcRelationProvider with Logging {
                     mode: SaveMode,
                     parameters: Map[String, String],
                     rawDf: DataFrame): BaseRelation = {
-        val options = new SQLServerBulkJdbcOptions(parameters)
+        val options = new SQLServerBulkJdbcOptions(parameters  + ("applicationname" -> parameters.getOrElse("applicationname", "Spark MSSQL Connector")))
         val conn = createConnectionFactory(options)()
         val df = repartitionDataFrame(rawDf, options)
 

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/BestEffortDataPoolStrategy.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/BestEffortDataPoolStrategy.scala
@@ -96,7 +96,7 @@ object BestEffortDataPoolStrategy extends DataIOStrategy with Logging {
         dfColMetadata:Array[ColumnMetadata]) : Unit = {
     logInfo(s"write: to hostname $hostname")
     val url = DataPoolUtils.createDataPoolURL(hostname, options)
-    val newOptions = new SQLServerBulkJdbcOptions(options.parameters + ("url" -> url))
+    val newOptions = new SQLServerBulkJdbcOptions(options.parameters + ("url" -> url)  + ("applicationname" -> options.parameters.getOrElse("applicationname", "Spark MSSQL Connector")))
     savePartition(iterator, options.dbtable, dfColMetadata, newOptions)
   }
 

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
@@ -95,7 +95,7 @@ object ReliableSingleInstanceStrategy extends  DataIOStrategy with Logging {
         (index, iterator) => {
           val table_name = getStagingTableName(appId,index)
           logDebug(s"writeToStagingTables: Writing partition index $index to Table $table_name")
-          val newOptions = new SQLServerBulkJdbcOptions(options.parameters + ("tableLock" -> "true"))
+          val newOptions = new SQLServerBulkJdbcOptions(options.parameters + ("tableLock" -> "true") + ("applicationname" -> options.parameters.getOrElse("applicationname", "Spark MSSQL Connector")))
           idempotentInsertToTable(iterator, table_name, dfColMetadata, newOptions)
           logInfo(s"writeToStagingTables: Successfully wrote partition $index to Table $table_name")
           Iterator[Int](1)


### PR DESCRIPTION
The change also respects the case when the user passes in applicationName in the `options` Map.