### PR TITLE
Switch CI to use Maven build and use a matrix strategy

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,8 +8,13 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        profile: ['spark24', 'spark30']
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v2
@@ -17,5 +22,5 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Run tests
-      run: sbt test
+    - name: Build and run tests
+      run: mvn clean package -P ${{ matrix.profile }}

--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,9 @@ project/project/
 project/target/
 target/
 .idea
+
+# VS Code
+.vscode
+.settings
+.classpath
+.project


### PR DESCRIPTION
CI will now exercise the matrix of building on Mac / Ubuntu and
Spark 2.4 and Spark 3.0 profiles. Given a lot of the developer base
for Spark and related projects uses Mac, we should ensure that this
connector builds on not only Ubuntu, but also on Mac.