### PR TITLE
[DRAFT] Support bulk insert into SQL Graph tables

### DIFF
--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
@@ -68,9 +68,11 @@ class SQLServerBulkJdbcOptions(val params: CaseInsensitiveMap[String])
   val allowEncryptedValueModifications =
     params.getOrElse("allowEncryptedValueModifications", "false").toBoolean
 
-
   val schemaCheckEnabled =
     params.getOrElse("schemaCheckEnabled", "true").toBoolean
+
+  val hideGraphColumns =
+    params.getOrElse("hideGraphColumns", "true").toBoolean
 
   // Not a feature
   // Only used for internally testing data idempotency


### PR DESCRIPTION
If user-configurable option `hideGraphColumns` is True (default)
treat SQL graph internal columns as computed columns; else treat
them as normal columns.

Addresses #78 