### PR TITLE
Spark 3.1.2 support

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        profile: ['spark24', 'spark30']
+        profile: ['spark31']
     timeout-minutes: 15
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.microsoft.azure</groupId>
     <artifactId>spark-mssql-connector</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>1.2.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>The Apache Spark Connector for SQL Server and Azure SQL is a high-performance connector that enables you to use transactional data in big data analytics and persists results for ad-hoc queries or reporting.</description>
     <url>https://github.com/microsoft/sql-spark-connector</url>
@@ -202,6 +202,9 @@
     <profiles>
         <profile>
             <id>spark31</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>2.12.11</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -242,5 +242,26 @@
         </dependency>
         </dependencies>
     </profile>
+        <profile>
+            <id>spark311</id>
+            <properties>
+                <scala.binary.version>2.12</scala.binary.version>
+                <scala.version>2.12.10</scala.version>
+                <spark.version>3.1.1</spark.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest_${scala.binary.version}</artifactId>
+                    <version>3.2.6</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>8.2.1.jre8</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -200,54 +200,12 @@
         </plugins>
     </build>
     <profiles>
-    <profile>
-        <id>spark24</id>
-        <properties>
-            <scala.binary.version>2.11</scala.binary.version>
-            <scala.version>2.11.12</scala.version>
-            <spark.version>2.4.6</spark.version>
-        </properties>
-        <dependencies>
-            <dependency>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest_${scala.binary.version}</artifactId>
-                <version>3.0.5</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.sqlserver</groupId>
-                <artifactId>mssql-jdbc</artifactId>
-                <version>8.4.1.jre8</version>
-            </dependency>
-        </dependencies>
-    </profile>
-    <profile>
-        <id>spark30</id>
-        <properties>
-            <scala.binary.version>2.12</scala.binary.version>
-            <scala.version>2.12.11</scala.version>
-            <spark.version>3.0.0</spark.version>
-        </properties>
-        <dependencies>
-        <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.0.8</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>mssql-jdbc</artifactId>
-            <version>8.4.1.jre8</version>
-        </dependency>
-        </dependencies>
-    </profile>
         <profile>
-            <id>spark311</id>
+            <id>spark31</id>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
-                <scala.version>2.12.10</scala.version>
-                <spark.version>3.1.1</spark.version>
+                <scala.version>2.12.11</scala.version>
+                <spark.version>3.1.2</spark.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -259,7 +217,7 @@
                 <dependency>
                     <groupId>com.microsoft.sqlserver</groupId>
                     <artifactId>mssql-jdbc</artifactId>
-                    <version>8.2.1.jre8</version>
+                    <version>8.4.1.jre8</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
@@ -499,7 +499,7 @@ object BulkCopyUtils extends Logging {
                         df: DataFrame,
                         options: SQLServerBulkJdbcOptions): Unit = {
         logDebug("Creating table")
-        val strSchema = schemaString(df, options.url, options.createTableColumnTypes)
+        val strSchema = schemaString(df.schema, true, options.url, options.createTableColumnTypes)
         val createTableStr = s"CREATE TABLE ${options.dbtable} (${strSchema}) ${options.createTableOptions}"
         executeUpdate(conn,createTableStr)
         logDebug("Creating table succeeded")
@@ -517,7 +517,7 @@ object BulkCopyUtils extends Logging {
         df: DataFrame,
         options: SQLServerBulkJdbcOptions): Unit = {
         logDebug(s"Creating external table ${options.dbtable}")
-        val strSchema = schemaString(df, "jdbc:sqlserver")
+        val strSchema = schemaString(df.schema, true, "jdbc:sqlserver")
         val createExTableStr =  s"CREATE EXTERNAL TABLE ${options.dbtable} (${strSchema}) " +
           s"WITH (DATA_SOURCE=${options.dataPoolDataSource}, DISTRIBUTION=${options.dataPoolDistPolicy});"
         executeUpdate(conn,createExTableStr)

--- a/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
@@ -11,7 +11,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package com.microsoft.sqlserver.jdbc.spark.bulkwrite;
+package com.microsoft.sqlserver.jdbc.spark;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -26,7 +26,6 @@ import org.apache.spark.sql.RowFactory;
 import scala.collection.Iterator;
 import scala.collection.JavaConversions;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
-import com.microsoft.sqlserver.jdbc.spark.*;
 
 public class DataSourceUtilsTest {
     @Test

--- a/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
+++ b/src/test/java/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceUtilsTest.java
@@ -11,7 +11,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package com.microsoft.sqlserver.jdbc.spark;
+package com.microsoft.sqlserver.jdbc.spark.bulkwrite;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -26,6 +26,7 @@ import org.apache.spark.sql.RowFactory;
 import scala.collection.Iterator;
 import scala.collection.JavaConversions;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
+import com.microsoft.sqlserver.jdbc.spark.*;
 
 public class DataSourceUtilsTest {
     @Test

--- a/src/test/scala/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceTest.scala
+++ b/src/test/scala/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceTest.scala
@@ -11,14 +11,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package com.microsoft.sqlserver.jdbc.spark.bulkwrite
+package com.microsoft.sqlserver.jdbc.spark
 import java.sql.Connection
 
 import org.scalatest.matchers.should.Matchers
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
-
-import com.microsoft.sqlserver.jdbc.spark._
 
 class DataSourceTest extends SparkFunSuite with Matchers with SharedSparkSession {
 

--- a/src/test/scala/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceTest.scala
+++ b/src/test/scala/com/microsoft/sqlserver/jdbc/spark/bulkwrite/DataSourceTest.scala
@@ -11,12 +11,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package com.microsoft.sqlserver.jdbc.spark
+package com.microsoft.sqlserver.jdbc.spark.bulkwrite
 import java.sql.Connection
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
+
+import com.microsoft.sqlserver.jdbc.spark._
 
 class DataSourceTest extends SparkFunSuite with Matchers with SharedSparkSession {
 

--- a/test/scala_test/pom.xml
+++ b/test/scala_test/pom.xml
@@ -123,19 +123,14 @@
     </build>
     <profiles>
         <profile>
-            <id>spark24</id>
-            <properties>
-                <scala.binary.version>2.11</scala.binary.version>
-                <scala.version>2.11.12</scala.version>
-                <spark.version>2.4.6</spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark30</id>
+            <id>spark31</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>2.12.11</scala.version>
-                <spark.version>3.0.0</spark.version>
+                <spark.version>3.1.2</spark.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
This PR enables support for spark 3.1. After this PR, spark 2.4 and 3.0 will not be supported. I would recommend to move 2.4/ 3.0 to another branch. I kept profile format in pom.xml, in case we might need to add another profile for new spark version.
When use connector creating table in spark 3.1, will get the error message below. This PR is cherry-picked from #100. This PR modified the schemaString() to enable the support for spark3.1.2.
```
java.lang.NoSuchMethodError: org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils$.schemaString(Lorg/apache/spark/sql/Dataset;Ljava/lang/String;Lscala/Option;)Ljava/lang/String;
```
In spark 3.1 and after, schemaString() changed from
```
schemaString(
      df: DataFrame,
      url: String,
      createTableColumnTypes: Option[String] = None)
```
to
```
schemaString(
      schema: StructType,
      caseSensitive: Boolean,
      url: String,
      createTableColumnTypes: Option[String] = None)
```
## test for this PR
This PR passed CI /GCI tests in BDC spark 3.1. I also built the scala test jar and spark-submit scala_test as below, and passed single instance and data pool tests.
spark-submit --master yarn --deploy-mode cluster --class SparkConnTestMain /tmp/spark-mssql-connector-scala-test-1.0.0.jar 'connector_user' 'password123!#' '' '' 'com.microsoft.sqlserver.jdbc.spark' 'connector_test_db' 'connector_ds' '0' 'true' 'master-p-svc' '1433' ''