### PR TITLE
remove brackets for staging table name in NO_DUPLICATES mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,9 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
+# IntelliJ build files
+spark-mssql-connector.iml
+
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/connectors/ReliableSingleInstanceStrategy.scala
@@ -181,8 +181,10 @@ object ReliableSingleInstanceStrategy extends  DataIOStrategy with Logging {
                appId: String,
                dbtable: String,
                index:Int) : String = {
+    // remove square brackets in db / schema / table name
+    val dbtableNew = dbtable.replaceAll("[\\[\\]]", "")
     // Global table names in SQLServer are prefixed with ##
-    s"[##${appId}_${dbtable}_${index}]"
+    s"[##${appId}_${dbtableNew}_${index}]"
   }
 
   /**

--- a/test/scala_test/src/main/scala/MasterInstanceTest.scala
+++ b/test/scala_test/src/main/scala/MasterInstanceTest.scala
@@ -424,8 +424,8 @@ class MasterInstanceTest(testUtils:Connector_TestUtils) {
     /*
      * OverWrite/Append and Read (OWAR) to SQL tables using 2 part names     *
      */
-    def test_gci__twoPartName_owar() {
-        val table = s"test_gci_threePartName_owar"
+    def test_gci_twoPartName_owar() {
+        val table = s"test_gci_twoPartName_owar"
         val twoPartName = testUtils.createTwoPartName(table)
         log.info(s"Tablename is $twoPartName \n")
         val df = testUtils.create_toy_df()
@@ -435,6 +435,22 @@ class MasterInstanceTest(testUtils:Connector_TestUtils) {
         val df_result = testUtils.df_read(twoPartName)
         assert(df_result.count() == 2*df.count())
         testUtils.drop_test_table(twoPartName)
+    }
+
+    /*
+     * OverWrite/Append and Read (OWAR) to SQL tables using 1 part name within square brackets     *
+     */
+    def test_gci_tbNameInBracket_owar() {
+        val table_name = s"[test_gci_tbNameInBracket_owar]"
+        log.info(s"Table name is $table_name \n")
+        val df = testUtils.create_toy_df()
+        log.info("Operation Overwrite, append and read\n")
+        testUtils.df_write(df, SaveMode.Overwrite, table_name)
+        testUtils.df_write(df, SaveMode.Append, table_name)
+        var result = testUtils.df_read(table_name)
+        assert(result.count() == 2 * df.count())
+        log.info("test_gci_tbNameInBracket_owar : Exit")
+        testUtils.drop_test_table(table_name)
     }
 
     /*


### PR DESCRIPTION
Currently we are using [##${appId}_${dbtable}_${index}] as staging table name for NO_DUPLICATES reliability mode. But it will cause error when user input ${dbtable} (table/ schema / db name) includes brackets. This PR will remove brackets in user input when forming staging table name.
## test
This PR has passed CI /GCI tests. I added a scala test, then built and ran the scala tests.