### PR TITLE
[DRAFT]Add support for Graph tables and temporary tables

### DIFF
--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
@@ -68,9 +68,11 @@ class SQLServerBulkJdbcOptions(val params: CaseInsensitiveMap[String])
   val allowEncryptedValueModifications =
     params.getOrElse("allowEncryptedValueModifications", "false").toBoolean
 
-
   val schemaCheckEnabled =
     params.getOrElse("schemaCheckEnabled", "true").toBoolean
+
+  val hideGraphColumns =
+    params.getOrElse("hideGraphColumns", "true").toBoolean
 
   // Not a feature
   // Only used for internally testing data idempotency

--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/SQLServerBulkJdbcOptions.scala
@@ -68,11 +68,9 @@ class SQLServerBulkJdbcOptions(val params: CaseInsensitiveMap[String])
   val allowEncryptedValueModifications =
     params.getOrElse("allowEncryptedValueModifications", "false").toBoolean
 
+
   val schemaCheckEnabled =
     params.getOrElse("schemaCheckEnabled", "true").toBoolean
-
-  val hideGraphColumns =
-    params.getOrElse("hideGraphColumns", "true").toBoolean
 
   // Not a feature
   // Only used for internally testing data idempotency


### PR DESCRIPTION
Current connector does not support 
An error occurred while calling o114.save.
: java.util.NoSuchElementException: key not found: validfrom
	at scala.collection.immutable.Map$Map3.apply(Map.scala:170)
	at com.microsoft.sqlserver.jdbc.spark.BulkCopyUtils$.$anonfun$matchSchemas$2(BulkCopyUtils.scala:343)
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:158)
	at com.microsoft.sqlserver.jdbc.spark.BulkCopyUtils$.matchSchemas(BulkCopyUtils.scala:327)
	at com.microsoft.sqlserver.jdbc.spark.BulkCopyUtils$.getColMetaData(BulkCopyUtils.scala:266)
	at com.microsoft.sqlserver.jdbc.spark.Connector.write(Connector.scala:79)