### PR TITLE
Skip table cols not in df when schemaCheck disabled

### DIFF
--- a/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
+++ b/src/main/scala/com/microsoft/sqlserver/jdbc/spark/utils/BulkCopyUtils.scala
@@ -276,30 +276,24 @@ object BulkCopyUtils extends Logging {
                 var dfFieldIndex = 0
                 var dfColName:String = ""
                 if (isCaseSensitive) {
-                    if (!dfCols.fieldNames.contains(tableColName)) {
-                        if (strictSchemaCheck) {
-                            throw new SQLException(s"SQL table column ${tableColName} not exist in df columns")
-                        } else {
-                            // when strictSchema check disabled, skip mapping / metadata if table col not in df col
-                            logDebug(s"skipping index $i sql col name $tableColName mapping and column metadata")
-                            break
-                        }
+                    if (!strictSchemaCheck && !dfCols.fieldNames.contains(tableColName)) {
+                        // when strictSchema check disabled, skip mapping / metadata if table col not in df col
+                        logDebug(s"skipping index $i sql col name $tableColName mapping and column metadata")
+                        break
                     }
+                    dfFieldIndex = dfCols.fieldIndex(tableColName)
                     dfColName = dfCols(dfFieldIndex).name
                     assertIfCheckEnabled(
                         tableColName == dfColName, strictSchemaCheck,
                         s"""${prefix} column names '${tableColName}' and
                         '${dfColName}' at column index ${i} (case sensitive)""")
                 } else {
-                    if (!dfColCaseMap.contains(tableColName.toLowerCase())) {
-                        if (strictSchemaCheck) {
-                            throw new SQLException(s"SQL table column ${tableColName} not exist in df columns")
-                        } else {
-                            // when strictSchema check disabled, skip mapping / metadata if table col not in df col
-                            logDebug(s"skipping index $i sql col name $tableColName mapping and column metadata")
-                            break
-                        }
+                    if (!strictSchemaCheck && !dfColCaseMap.contains(tableColName.toLowerCase())) {
+                        // when strictSchema check disabled, skip mapping / metadata if table col not in df col
+                        logDebug(s"skipping index $i sql col name $tableColName mapping and column metadata")
+                        break
                     }
+                    dfFieldIndex = dfCols.fieldIndex(dfColCaseMap(tableColName.toLowerCase()))
                     dfColName = dfCols(dfFieldIndex).name
                     assertIfCheckEnabled(
                         tableColName.toLowerCase() == dfColName.toLowerCase(),


### PR DESCRIPTION
This PR will skip the cols not exist in df when strictSchemaCheck disabled. This PR will enable below two use cases.
1. Auto generated columns. These columns cannot be generated by source df. Including computed columns, temporal table(always generated), graph tables...
2. Source df has less columns than sql table. (e.g. When SQL table has hundreds of cols while user only want to insert some of columns and all the reset columns remain null). 

## Test
This PR passed the CI / GCI tests. I also added test cases/ examples for computed cols, temporal table, graph table in notebook in PR #160 .