### PR TITLE
remove sparkContext stop statement

### DIFF
--- a/test/scala_test/src/main/scala/scala_test.scala
+++ b/test/scala_test/src/main/scala/scala_test.scala
@@ -135,7 +135,6 @@ object SparkConnTestMain {
                 method.invoke(test_obj)
             }
         }
-        test_obj.spark.sparkContext.stop()
     }
 }
 


### PR DESCRIPTION
This PR fixes Spark job null pointer error in databricks.
This PR is tested on DBR 11.3.