### PR TITLE
Upgrade to Spark 3.4.0

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        profile: ['spark33']
+        profile: ['spark34']
     timeout-minutes: 15
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ There are three version sets of the connector available through Maven, a 2.4.x, 
 | Spark 3.0.x compatible connector | `com.microsoft.azure:spark-mssql-connector_2.12:1.1.0` | 2.12          |
 | Spark 3.1.x compatible connector | `com.microsoft.azure:spark-mssql-connector_2.12:1.2.0` | 2.12          |
 | Spark 3.3.x compatible connector | `com.microsoft.azure:spark-mssql-connector_2.12:1.3.0` | 2.12          |
+| Spark 3.4.x compatible connector | `com.microsoft.azure:spark-mssql-connector_2.12:1.4.0` | 2.12          |
 
 ## Current Releases
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.microsoft.azure</groupId>
     <artifactId>spark-mssql-connector</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>The Apache Spark Connector for SQL Server and Azure SQL is a high-performance connector that enables you to use transactional data in big data analytics and persists results for ad-hoc queries or reporting.</description>
     <url>https://github.com/microsoft/sql-spark-connector</url>
@@ -201,14 +201,14 @@
     </build>
     <profiles>
         <profile>
-            <id>spark33</id>
+            <id>spark34</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>2.12.11</scala.version>
-                <spark.version>3.3.0</spark.version>
+                <spark.version>3.4.0</spark.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/test/scala_test/pom.xml
+++ b/test/scala_test/pom.xml
@@ -123,14 +123,14 @@
     </build>
     <profiles>
         <profile>
-            <id>spark33</id>
+            <id>spark34</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>2.12.11</scala.version>
-                <spark.version>3.3.0</spark.version>
+                <spark.version>3.4.0</spark.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Changes similar to those of the previous upgrade to 3.3 at https://github.com/microsoft/sql-spark-connector/pull/197

* Bump Spark to 3.4.0
* Bumped the version of the library to 1.4.0
* Updated the readme accordingly
  * Added the 1.4.0 artifact to the version table

Fixes https://github.com/microsoft/sql-spark-connector/issues/227, specifically `java.lang.NoSuchMethodError: 'org.apache.spark.sql.types.StructType org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils$.getSchema(java.sql.ResultSet, org.apache.spark.sql.jdbc.JdbcDialect, boolean)'`

